### PR TITLE
contract improvements

### DIFF
--- a/src/contracts/giftcard_approval.teal
+++ b/src/contracts/giftcard_approval.teal
@@ -26,8 +26,8 @@ main_l6:
 global GroupSize
 int 2
 ==
-txn NumAppArgs
-int 2
+txn GroupIndex
+int 0
 ==
 &&
 byte "BOUGHT"
@@ -35,12 +35,17 @@ app_global_get
 int 0
 ==
 &&
+byte "OWNER"
+app_global_get
+txn Sender
+!=
+&&
 assert
 gtxn 1 TypeEnum
 int pay
 ==
 gtxn 1 Receiver
-byte "ADDRESS"
+byte "OWNER"
 app_global_get
 ==
 &&
@@ -55,10 +60,7 @@ gtxn 0 Sender
 &&
 assert
 byte "OWNER"
-txna ApplicationArgs 1
-app_global_put
-byte "ADDRESS"
-gtxn 1 Sender
+txna Accounts 0
 app_global_put
 byte "AMOUNT"
 byte "AMOUNT"
@@ -78,17 +80,17 @@ global CreatorAddress
 return
 main_l8:
 txn NumAppArgs
-int 5
+int 4
 ==
-assert
 txn Note
-byte "giftcard:uv2"
+byte "giftcard:uv3"
 ==
-assert
+&&
 txna ApplicationArgs 3
 btoi
 int 0
 >
+&&
 assert
 byte "NUMBER"
 txna ApplicationArgs 0
@@ -106,11 +108,8 @@ app_global_put
 byte "BOUGHT"
 int 0
 app_global_put
-byte "ADDRESS"
-global CreatorAddress
-app_global_put
 byte "OWNER"
-txna ApplicationArgs 4
+txna Accounts 0
 app_global_put
 int 1
 return

--- a/src/contracts/giftcard_approval.teal
+++ b/src/contracts/giftcard_approval.teal
@@ -2,32 +2,72 @@
 txn ApplicationID
 int 0
 ==
-bnz main_l8
+bnz main_l16
 txn OnCompletion
 int DeleteApplication
 ==
-bnz main_l7
+bnz main_l15
+txn OnCompletion
+int OptIn
+==
+bnz main_l14
+txna ApplicationArgs 0
+byte "activate"
+==
+bnz main_l13
 txna ApplicationArgs 0
 byte "buy"
 ==
-bnz main_l6
+bnz main_l12
+txna ApplicationArgs 0
+byte "buy"
+==
+bnz main_l9
 txna ApplicationArgs 0
 byte "sell"
 ==
-bnz main_l5
+bnz main_l8
 err
-main_l5:
+main_l8:
+byte "BOUGHT"
+app_global_get
+int 1
+==
+byte "OWNER"
+app_global_get
+txn Sender
+==
+&&
+assert
 byte "BOUGHT"
 int 0
 app_global_put
 int 1
 return
-main_l6:
+main_l9:
+txna Accounts 0
+txna Applications 0
+app_opted_in
 global GroupSize
 int 2
 ==
+&&
 txn GroupIndex
 int 0
+==
+&&
+txn NumAccounts
+int 1
+==
+&&
+txna Accounts 1
+byte "OWNER"
+app_global_get
+==
+&&
+byte "ACTIVATED"
+app_global_get
+int 1
 ==
 &&
 byte "BOUGHT"
@@ -59,6 +99,24 @@ gtxn 0 Sender
 ==
 &&
 assert
+txna Accounts 1
+txna Applications 0
+byte "NUMBER"
+app_local_get_ex
+store 1
+store 0
+load 1
+bnz main_l11
+int 0
+return
+main_l11:
+txna Accounts 0
+byte "NUMBER"
+load 0
+app_local_put
+txna Accounts 1
+byte "NUMBER"
+app_local_del
 byte "OWNER"
 txna Accounts 0
 app_global_put
@@ -73,14 +131,81 @@ int 1
 app_global_put
 int 1
 return
-main_l7:
+main_l12:
+txna Accounts 0
+txna Applications 0
+app_opted_in
+txn NumAccounts
+int 1
+==
+&&
+txna Accounts 1
+txna Applications 0
+app_opted_in
+&&
+byte "ACTIVATED"
+app_global_get
+int 1
+==
+&&
+txn Sender
+byte "OWNER"
+app_global_get
+==
+&&
+assert
+txna Accounts 1
+byte "NUMBER"
+txna Accounts 0
+byte "NUMBER"
+app_local_get
+app_local_put
+txna Accounts 0
+byte "NUMBER"
+app_local_del
+byte "OWNER"
+txna Accounts 1
+app_global_put
+int 1
+return
+main_l13:
+txna Accounts 0
+txna Applications 0
+app_opted_in
+txn NumAppArgs
+int 2
+==
+&&
+byte "ACTIVATED"
+app_global_get
+int 0
+==
+&&
+txn Sender
+global CreatorAddress
+==
+&&
+assert
+txna Accounts 0
+byte "NUMBER"
+txna ApplicationArgs 1
+app_local_put
+byte "ACTIVATED"
+int 1
+app_global_put
+int 1
+return
+main_l14:
+int 1
+return
+main_l15:
 txn Sender
 global CreatorAddress
 ==
 return
-main_l8:
+main_l16:
 txn NumAppArgs
-int 4
+int 3
 ==
 txn Note
 byte "giftcard:uv3"
@@ -92,18 +217,18 @@ int 0
 >
 &&
 assert
-byte "NUMBER"
+byte "DESCRIPTION"
 txna ApplicationArgs 0
 app_global_put
-byte "DESCRIPTION"
+byte "IMAGE"
 txna ApplicationArgs 1
 app_global_put
-byte "IMAGE"
-txna ApplicationArgs 2
-app_global_put
 byte "AMOUNT"
-txna ApplicationArgs 3
+txna ApplicationArgs 2
 btoi
+app_global_put
+byte "ACTIVATED"
+int 0
 app_global_put
 byte "BOUGHT"
 int 0

--- a/src/contracts/giftcard_contract.py
+++ b/src/contracts/giftcard_contract.py
@@ -1,5 +1,6 @@
 from pyteal import *
 
+
 class GiftCard:
     class Variables:
         number = Bytes("NUMBER")
@@ -7,60 +8,81 @@ class GiftCard:
         image = Bytes("IMAGE")
         amount = Bytes("AMOUNT")
         bought = Bytes("BOUGHT")
-        address = Bytes("ADDRESS")
-        owner = Bytes("OWNER")
+        current_owner = Bytes("OWNER")
 
     class AppMethods:
         buy = Bytes("buy")
         sell = Bytes("sell")
 
+    # allow users to create a new gift card application
     def application_creation(self):
         return Seq([
-            Assert(Txn.application_args.length() == Int(5)),
-            Assert(Txn.note() == Bytes("giftcard:uv2")),
-             Assert(Btoi(Txn.application_args[3]) > Int(0)),
+            Assert(
+                # run the following checks that:
+                And(
+                    # The number of arguments attached to the transaction should be exactly 4.
+                    Txn.application_args.length() == Int(4),
+                    # The note attached to the transaction must be "giftcard:uv3".
+                    Txn.note() == Bytes("giftcard:uv3"),
+                    # The giftcard price is greater than 0
+                    Btoi(Txn.application_args[3]) > Int(0),
+                )
+            ),
             App.globalPut(self.Variables.number, Txn.application_args[0]),
             App.globalPut(self.Variables.description, Txn.application_args[1]),
             App.globalPut(self.Variables.image, Txn.application_args[2]),
-            App.globalPut(self.Variables.amount, Btoi(Txn.application_args[3])),
+            App.globalPut(self.Variables.amount,
+                          Btoi(Txn.application_args[3])),
             App.globalPut(self.Variables.bought, Int(0)),
-            App.globalPut(self.Variables.address, Global.creator_address()),
-            App.globalPut(self.Variables.owner, Txn.application_args[4]),
+            App.globalPut(self.Variables.current_owner, Txn.accounts[0]),
             Approve()
         ])
 
+    # allow users to buy a gift card that hasn't been bought yet
     def buyCard(self):
         return Seq([
             Assert(
+                # run the following checks that:
                 And(
+                    # The transaction group is made up of 2 transactions
                     Global.group_size() == Int(2),
-                    Txn.application_args.length() == Int(2),
-                    App.globalGet(self.Variables.bought) == Int(0)
+                    # The buyCard txn is made ahead of the payment transaction
+                    Txn.group_index() == Int(0),
+                    # The item hasn't been bought
+                    App.globalGet(self.Variables.bought) == Int(0),
+                    # The sender of transaction is not the giftcard owner
+                    App.globalGet(
+                        self.Variables.current_owner) != Txn.sender(),
                 ),
             ),
             Assert(
+                # checks for the payment transaction
                 And(
                     Gtxn[1].type_enum() == TxnType.Payment,
                     Gtxn[1].receiver() == App.globalGet(
-                        self.Variables.address),
+                        self.Variables.current_owner),
                     Gtxn[1].amount() == App.globalGet(self.Variables.amount),
                     Gtxn[1].sender() == Gtxn[0].sender(),
                 )
             ),
 
-            App.globalPut(self.Variables.owner, Txn.application_args[1]),
-            App.globalPut(self.Variables.address, Gtxn[1].sender()),
-            App.globalPut(self.Variables.amount, App.globalGet(self.Variables.amount) * Int(2)),
+            App.globalPut(self.Variables.current_owner, Txn.accounts[0]),
+            App.globalPut(self.Variables.amount, App.globalGet(
+                self.Variables.amount) * Int(2)),
             App.globalPut(self.Variables.bought, Int(1)),
             Approve()
         ])
 
+    # allow gift cards' owners to sell their gift cards
     def sellGiftCard(self):
         Assert(
+            # run the following checks that:
             And(
-                Txn.application_args.length() == Int(2),
+                # The gift card is already bought
+                App.globalGet(self.Variables.bought) == Int(1),
+                # The sender is the gift card's owner
                 App.globalGet(
-                    self.Variables.owner) == Txn.application_args[1]
+                    self.Variables.current_owner) == Txn.sender(),
             ),
         )
 
@@ -86,6 +108,3 @@ class GiftCard:
 
     def clear_program(self):
         return Return(Int(1))
-
-
-        

--- a/src/contracts/giftcard_contract.py
+++ b/src/contracts/giftcard_contract.py
@@ -2,17 +2,22 @@ from pyteal import *
 
 
 class GiftCard:
-    class Variables:
-        number = Bytes("NUMBER")
+    class GlobalVariables:
         description = Bytes("DESCRIPTION")
         image = Bytes("IMAGE")
         amount = Bytes("AMOUNT")
+        activated = Bytes("ACTIVATED")
         bought = Bytes("BOUGHT")
         current_owner = Bytes("OWNER")
 
     class AppMethods:
+        activate = Bytes("activate")
         buy = Bytes("buy")
+        gift = Bytes("gift")
         sell = Bytes("sell")
+
+    class LocalVariables:
+        number = Bytes("NUMBER")
 
     # allow users to create a new gift card application
     def application_creation(self):
@@ -20,74 +25,175 @@ class GiftCard:
             Assert(
                 # run the following checks that:
                 And(
-                    # The number of arguments attached to the transaction should be exactly 4.
-                    Txn.application_args.length() == Int(4),
+                    # The number of arguments attached to the transaction should be exactly 3.
+                    Txn.application_args.length() == Int(3),
                     # The note attached to the transaction must be "giftcard:uv3".
                     Txn.note() == Bytes("giftcard:uv3"),
                     # The giftcard price is greater than 0
                     Btoi(Txn.application_args[3]) > Int(0),
                 )
             ),
-            App.globalPut(self.Variables.number, Txn.application_args[0]),
-            App.globalPut(self.Variables.description, Txn.application_args[1]),
-            App.globalPut(self.Variables.image, Txn.application_args[2]),
-            App.globalPut(self.Variables.amount,
-                          Btoi(Txn.application_args[3])),
-            App.globalPut(self.Variables.bought, Int(0)),
-            App.globalPut(self.Variables.current_owner, Txn.accounts[0]),
+            App.globalPut(self.GlobalVariables.description,
+                          Txn.application_args[0]),
+            App.globalPut(self.GlobalVariables.image, Txn.application_args[1]),
+            App.globalPut(self.GlobalVariables.amount,
+                          Btoi(Txn.application_args[2])),
+            App.globalPut(self.GlobalVariables.activated, Int(0)),
+            App.globalPut(self.GlobalVariables.bought, Int(0)),
+            App.globalPut(self.GlobalVariables.current_owner, Txn.accounts[0]),
             Approve()
         ])
 
-    # allow users to buy a gift card that hasn't been bought yet
-    def buyCard(self):
+    # opt in to contract
+    def optIn(self):
+        return Approve()
+
+    # allow user to activate the gift card and input the gift card number
+    def activate_gift_card(self):
         return Seq([
             Assert(
                 # run the following checks that:
                 And(
+                    # that user has opted in
+                    App.optedIn(Txn.accounts[0], Txn.applications[0]),
+                    # The number of arguments attached to the transaction should be exactly 2.
+                    Txn.application_args.length() == Int(2),
+                    # The gift card has not been acutivated
+                    App.globalGet(self.GlobalVariables.activated) == Int(0),
+                    # The sender is the giftcard creator
+                    Txn.sender() == Global.creator_address()
+                ),
+            ),
+            # store giftcard number in user local state
+            App.localPut(
+                Txn.accounts[0], self.LocalVariables.number, Txn.application_args[1]),
+            # set giftcard as activated
+            App.globalPut(self.GlobalVariables.activated, Int(1)),
+            Approve()
+        ])
+
+    # allow users to send a gift card to another user
+    def gift_card(self):
+        gift_card_number = App.localGet(
+            Txn.accounts[0], self.LocalVariables.number)
+        return Seq([
+            Assert(
+                # run the following checks that:
+                And(
+                    # that owner has opted in
+                    App.optedIn(Txn.accounts[0], Txn.applications[0]),
+                    # The accounts array is not empty
+                    Txn.accounts.length() == Int(1),
+                    # that receiver has opted in
+                    App.optedIn(Txn.accounts[1], Txn.applications[0]),
+                    # The gift card has been activated
+                    App.globalGet(self.GlobalVariables.activated) == Int(1),
+                    # The sender is the giftcard owner
+                    Txn.sender() == App.globalGet(self.GlobalVariables.current_owner),
+                ),
+            ),
+            # store giftcard number in receiver's local state
+            App.localPut(
+                Txn.accounts[1], self.LocalVariables.number, gift_card_number),
+
+            # delete giftcard number from owner's local state
+            App.localDel(Txn.accounts[0], self.LocalVariables.number),
+
+            # store receiver's address as current owner
+            App.globalPut(
+                self.GlobalVariables.current_owner, Txn.accounts[1]),
+
+            Approve()
+        ])
+
+    # allow users to buy a gift card that hasn't been bought yet
+    def buy_card(self):
+        current_owner = App.globalGet(
+            self.GlobalVariables.current_owner)
+
+        # sequence that checks current owner's state for giftcard
+        check_giftcard_number = App.localGetEx(
+            Txn.accounts[1], Txn.applications[0], self.LocalVariables.number)
+        return Seq([
+            Assert(
+                # run the following checks that:
+                And(
+                    # that user has opted in
+                    App.optedIn(Txn.accounts[0], Txn.applications[0]),
                     # The transaction group is made up of 2 transactions
                     Global.group_size() == Int(2),
                     # The buyCard txn is made ahead of the payment transaction
                     Txn.group_index() == Int(0),
-                    # The item hasn't been bought
-                    App.globalGet(self.Variables.bought) == Int(0),
+                    # The accounts array is not empty
+                    Txn.accounts.length() == Int(1),
+                    # The address passed in is the current owner of gift card
+                    Txn.accounts[1] == current_owner,
+                    # The gift card has not been activated
+                    App.globalGet(self.GlobalVariables.activated) == Int(1),
+                    # The gift card hasn't been bought
+                    App.globalGet(self.GlobalVariables.bought) == Int(0),
                     # The sender of transaction is not the giftcard owner
-                    App.globalGet(
-                        self.Variables.current_owner) != Txn.sender(),
-                ),
+                   current_owner != Txn.sender(),
+                   ),
             ),
             Assert(
                 # checks for the payment transaction
                 And(
                     Gtxn[1].type_enum() == TxnType.Payment,
                     Gtxn[1].receiver() == App.globalGet(
-                        self.Variables.current_owner),
-                    Gtxn[1].amount() == App.globalGet(self.Variables.amount),
+                        self.GlobalVariables.current_owner),
+                    Gtxn[1].amount() == App.globalGet(
+                        self.GlobalVariables.amount),
                     Gtxn[1].sender() == Gtxn[0].sender(),
                 )
             ),
 
-            App.globalPut(self.Variables.current_owner, Txn.accounts[0]),
-            App.globalPut(self.Variables.amount, App.globalGet(
-                self.Variables.amount) * Int(2)),
-            App.globalPut(self.Variables.bought, Int(1)),
-            Approve()
+            # check for giftcard number in current owner's local state
+            check_giftcard_number,
+
+            # if check returns a value
+            If(check_giftcard_number.hasValue())
+            .Then(
+                Seq([
+                    # store giftcard number in txn sender's local state
+                    App.localPut(
+                        Txn.accounts[0], self.LocalVariables.number, check_giftcard_number.value()),
+
+                    # delete giftcard number from previous owner's local state
+                    App.localDel(Txn.accounts[1], self.LocalVariables.number),
+
+                    # store txn sender's address as current owner
+                    App.globalPut(
+                        self.GlobalVariables.current_owner, Txn.accounts[0]),
+
+                    # update amount
+                    App.globalPut(self.GlobalVariables.amount, App.globalGet(
+                        self.GlobalVariables.amount) * Int(2)),
+
+                    # set giftcard as bought
+                    App.globalPut(self.GlobalVariables.bought, Int(1)),
+                    Approve()
+                ])
+            )
+            .Else(
+                Reject()
+            ),
         ])
 
     # allow gift cards' owners to sell their gift cards
-    def sellGiftCard(self):
-        Assert(
-            # run the following checks that:
-            And(
-                # The gift card is already bought
-                App.globalGet(self.Variables.bought) == Int(1),
-                # The sender is the gift card's owner
-                App.globalGet(
-                    self.Variables.current_owner) == Txn.sender(),
-            ),
-        )
-
+    def sell_gift_card(self):
         return Seq([
-            App.globalPut(self.Variables.bought, Int(0)),
+            Assert(
+                # run the following checks that:
+                And(
+                    # The gift card is already bought
+                    App.globalGet(self.GlobalVariables.bought) == Int(1),
+                    # The sender is the gift card's owner
+                    App.globalGet(
+                        self.GlobalVariables.current_owner) == Txn.sender(),
+                ),
+            ),
+            App.globalPut(self.GlobalVariables.bought, Int(0)),
             Approve()
         ])
 
@@ -99,8 +205,12 @@ class GiftCard:
             [Txn.application_id() == Int(0), self.application_creation()],
             [Txn.on_completion() == OnComplete.DeleteApplication,
              self.application_deletion()],
-            [Txn.application_args[0] == self.AppMethods.buy, self.buyCard()],
-            [Txn.application_args[0] == self.AppMethods.sell, self.sellGiftCard()],
+            [Txn.on_completion() == OnComplete.OptIn, self.optIn()],
+            [Txn.application_args[0] == self.AppMethods.activate,
+                self.activate_gift_card()],
+            [Txn.application_args[0] == self.AppMethods.buy, self.gift_card()],
+            [Txn.application_args[0] == self.AppMethods.buy, self.buy_card()],
+            [Txn.application_args[0] == self.AppMethods.sell, self.sell_gift_card()],
         )
 
     def approval_program(self):

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,8 @@
+import algosdk from "algosdk";
+import { Base64 } from "js-base64";
+
+// Convert 32 byte address to readable 58 byte string
+export const getAddress = (addr) => {
+  if (!addr) return;
+  return algosdk.encodeAddress(Base64.toUint8Array(addr));
+};


### PR DESCRIPTION
### Contract Optimization

-  Noticed you kept passing in the sender address as part of the application arguments, removed that implementation and used the `Txn.accounts` array which supplies the 32-byte address of the transaction sender. This in turn reduces the number of transaction arguments. Then I added a helper function that helps convert the 32-byte address gotten from the owner global state query to the readable 58-byte address string.
- Removed unnecessary variables from the global state.
- Also noticed that the gift card number was left exposed and accessible for anyone who can read the contract, So I updated the contract to be able to use the user's local state,  so the gift card number is stored in the app creator's local state, but after creation, the app creator must first `opt-in` and then call the `activate_gift_card` method passing in the gift-card number which then stores the number in the user's local state (you can decide to make this a group transaction i.e. the opting in and card activation).
- Updates for the `buy_card` methods. Buyer must also `opt-in` to the application, after which on completion the gift-card number is transferred to the buyer's local state and deleted from the seller's local state.
- Also added a new feature that allows users to be able to send their gift cards to other users, but the receiver of the gift card must have opted-in to the application
- Also Improved documentation of code.
